### PR TITLE
Don't use a pseudo-TTY unless input is a TTY

### DIFF
--- a/commands
+++ b/commands
@@ -8,17 +8,23 @@ if [[ $1 == psql:* ]]; then
   load_ip_and_container
 fi
 
+if [ -t 0 ]; then
+  INTERACTIVE_DOCKER_EXEC="docker exec --interactive --tty"
+else
+  INTERACTIVE_DOCKER_EXEC="docker exec --interactive"
+fi
+
 case "$1" in
   psql:admin_console)
     check_container
-    docker exec -it "$PSQL_CONTAINER_NAME" env TERM=$TERM su - postgres -c psql
+    $INTERACTIVE_DOCKER_EXEC "$PSQL_CONTAINER_NAME" env TERM=$TERM su - postgres -c psql
     ;;
 
   psql:console)
     check_container; check_app; verify_app_name "$APP"; check_exists
     DATABASE=$(cat "$PSQL_ROOT/db_$APP")
     PASSWORD=$(cat "$PSQL_ROOT/pass_$APP")
-    docker exec -it "$PSQL_CONTAINER_NAME" env TERM="$TERM" PGPASSWORD="$PASSWORD" psql -h localhost -U "$DATABASE" "$DATABASE"
+    $INTERACTIVE_DOCKER_EXEC "$PSQL_CONTAINER_NAME" env TERM="$TERM" PGPASSWORD="$PASSWORD" psql -h localhost -U "$DATABASE" "$DATABASE"
     ;;
 
   psql:url)
@@ -54,7 +60,7 @@ case "$1" in
 
   psql:list)
     check_container
-    docker exec -it "$PSQL_CONTAINER_NAME" env TERM=$TERM su - postgres -c "psql --command \"\\l\""
+    $INTERACTIVE_DOCKER_EXEC "$PSQL_CONTAINER_NAME" env TERM=$TERM su - postgres -c "psql --command \"\\l\""
     ;;
 
   psql:start)


### PR DESCRIPTION
Instead of allocating a pseudo-TTY for any interactive command, only do so if the input is actually a TTY. This allows commands to be piped into `psql:console`, for example to set up a database from an SQL file.

Before:

```
$ echo 'select 1;' | dokku psql:console myapp
FATA[0000] cannot enable tty mode on non tty input
```

After:

```
$ echo 'select 1;' | dokku psql:console myapp
 ?column? 
----------
        1
(1 row)

$ dokku psql:console myapp                        
psql (9.3.6)
Type "help" for help.

myapp=> 
```
