### PR TITLE
Add note about dokku user permissions when using PSQL_SC_ROOT

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,9 @@ dokku config:set --global PSQL_SC_IMAGE=postgres:9.4
 
 By default, this plugin stores its data in `$DOKKU_ROOT/.psql-sc`. If you want
 to store it elsewhere, you have to set the `PSQL_SC_ROOT` in the global dokku
-config. You should do it **before** running `dokku plugins-install`.
+config. You should do it **before** running `dokku plugins-install`. **Note:** 
+If you are using custom `PSQL_SC_ROOT` directory, make sure it is writable by 
+`dokku` user.
 
 ```bash
 dokku config:set --global PSQL_SC_ROOT=/my/custom/path


### PR DESCRIPTION
I spent some 20 minutes trying to find out why custom PSQL_SC_ROOT isn't working until i realised i created it by root, but config files are written by dokku user.
