### PR TITLE
database_name() output changed to db_<appname>

### DIFF
--- a/functions
+++ b/functions
@@ -38,7 +38,7 @@ db_url() {
 }
 
 database_name() {
-  echo "$1" | tr .- _
+  echo "db_$1" | tr .- _
 }
 
 env_for() {


### PR DESCRIPTION
Plugin failed if app's name was a postgresql reserved word.
