### PR TITLE
fixed strange column multibyte error

### DIFF
--- a/commands
+++ b/commands
@@ -143,7 +143,7 @@ case "$1" in
     psql:restore <app> < <filename.*>, Restore database to <app> from any non-plain-text format exported by pg_dump
     psql:admin_console, Launch a postgresql console as admin user
     psql:restart, Restart the Postgresql docker container
-    psql:start, Start the Postgresql docker container if it isn’t running
+    psql:start, Start the Postgresql docker container if it isn't running
     psql:stop, Stop the Postgresql docker container
     psql:status, Shows status of Postgresql
     psql:list, List all databases


### PR DESCRIPTION
Since dokku 0.5.5 I had some strange error character error on `dokku help` on several systems. 

```
Community plugin commands:

column: Invalid or incomplete multibyte or wide character
    psql:admin_console                  Launch a postgresql console as admin user
    psql:console <app>                  Launch a postgresql console for <app>
    psql:create <app>                   Create a Postgresql database for <app>
```

I'm not sure why this wasn't an issue before, but removing the multibyte apostrophe fixes everything and help output is perfect again.
